### PR TITLE
HMS-36:Implemented Password-Reset mechanism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-plugins {
+	plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.5'
 	id 'io.spring.dependency-management' version '1.1.6'
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'

--- a/src/main/java/com/Java/hotelmanagementsystem/auth/controller/AuthenticationController.java
+++ b/src/main/java/com/Java/hotelmanagementsystem/auth/controller/AuthenticationController.java
@@ -1,6 +1,10 @@
 package com.Java.hotelmanagementsystem.auth.controller;
 import com.Java.hotelmanagementsystem.auth.model.AuthRequest;
 import com.Java.hotelmanagementsystem.auth.service.AuthenticationService;
+
+import com.Java.hotelmanagementsystem.email.dto.ForgotPasswordRequest;
+import com.Java.hotelmanagementsystem.email.dto.ResetPasswordRequest;
+import com.Java.hotelmanagementsystem.email.service.PasswordResetService;
 import com.Java.hotelmanagementsystem.user.model.User;
 import com.Java.hotelmanagementsystem.user.service.UserService;
 import com.Java.hotelmanagementsystem.util.RestHelper;
@@ -23,6 +27,10 @@ public class AuthenticationController {
 
     @Autowired
     private UserService userService;
+
+
+    @Autowired
+    private PasswordResetService passwordResetService;
 
     /**
      * Handles the authentication for the user provided credentials.
@@ -66,4 +74,31 @@ public class AuthenticationController {
         listHashMap.put("user", userService.save(user));
         return RestHelper.responseSuccess(listHashMap);
     }
+
+    /**
+     * Sends the password reset link to the concerned email.
+     *
+     * @param request The password request body containing the email of the user whose password is to be reset.
+     * @return The confirmation that the password reset link has been sent.
+     */
+    @PostMapping("/forgot-password")
+    public ResponseEntity<RestResponse> forgotPassword(@RequestBody ForgotPasswordRequest request) {
+        String message = passwordResetService.forgotPassword(request);
+        return RestHelper.responseMessage(message);
+    }
+
+    /**
+     * Resets the password from the provided token and the password.
+     *
+     * @param resetPasswordRequest The reset password request containing the jwt token and the password.
+     * @return The message indicating that the password has been reset successfully.
+     */
+    @PostMapping("/reset-password")
+    public ResponseEntity<RestResponse> resetPassword(@RequestBody ResetPasswordRequest resetPasswordRequest) {
+        String message = passwordResetService.resetPassword(resetPasswordRequest);
+        return RestHelper.responseMessage(message);
+    }
+
+
+
 }

--- a/src/main/java/com/Java/hotelmanagementsystem/config/SecurityConfig.java
+++ b/src/main/java/com/Java/hotelmanagementsystem/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable()) // Disable CSRF for stateless APIs
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/login", "/api/v1/auth/sign-up").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/login", "/api/v1/auth/sign-up",
+                                "/api/v1/auth/forgot-password", "/api/v1/auth/reset-password").permitAll()
                         .anyRequest().authenticated() // Protect all other endpoints
                 )
                 .sessionManagement(sessionManager -> sessionManager

--- a/src/main/java/com/Java/hotelmanagementsystem/email/dto/ForgotPasswordRequest.java
+++ b/src/main/java/com/Java/hotelmanagementsystem/email/dto/ForgotPasswordRequest.java
@@ -1,0 +1,12 @@
+package com.Java.hotelmanagementsystem.email.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ForgotPasswordRequest {
+    @NotBlank(message = "Email is required and cannot be empty")
+    @Email(message = "Invalid email format")
+    private String email;
+}

--- a/src/main/java/com/Java/hotelmanagementsystem/email/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/Java/hotelmanagementsystem/email/dto/ResetPasswordRequest.java
@@ -1,0 +1,15 @@
+package com.Java.hotelmanagementsystem.email.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ResetPasswordRequest {
+
+    @NotBlank(message = "Token cannot be empty")
+    private String token;
+
+    @NotBlank(message = "Password cannot be empty")
+    private String password;
+}

--- a/src/main/java/com/Java/hotelmanagementsystem/email/model/PasswordResetToken.java
+++ b/src/main/java/com/Java/hotelmanagementsystem/email/model/PasswordResetToken.java
@@ -1,0 +1,48 @@
+package com.Java.hotelmanagementsystem.email.model;
+
+
+import com.Java.hotelmanagementsystem.user.model.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "password_reset_token")
+public class PasswordResetToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String token;
+
+    @OneToOne(targetEntity = User.class, fetch = FetchType.EAGER)
+    @JoinColumn(nullable = false, name = "user_id")
+    private User user;
+
+    @Column(name = "expiry_date")
+    private Date expiryDate;
+
+    public PasswordResetToken(User user, String token) {
+        this.user = user;
+        this.token = token;
+        this.expiryDate = new Date(System.currentTimeMillis() + 1800000); // 30 minutes
+    }
+
+    public boolean isExpired() {
+        return new Date().after(this.expiryDate);
+    }
+}

--- a/src/main/java/com/Java/hotelmanagementsystem/email/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/Java/hotelmanagementsystem/email/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,32 @@
+package com.Java.hotelmanagementsystem.email.repository;
+
+import com.Java.hotelmanagementsystem.email.model.PasswordResetToken;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+
+    /**
+     * Retrieves the password reset token entity for the dedicated token.
+     *
+     * @param token The token assigned for the dedicated user.
+     * @return The optional valued password reset token entity.
+     */
+    Optional<PasswordResetToken> findByToken(String token);
+
+    /**
+     * Deletes any token present for the dedicated user.
+     *
+     * @param userId The user identifier of the user.
+     */
+    @Modifying
+    @Transactional
+    @Query(value = "delete from password_reset_token where user_id = :userId", nativeQuery = true)
+    void deleteByUserId(long userId);
+}

--- a/src/main/java/com/Java/hotelmanagementsystem/email/service/EmailService.java
+++ b/src/main/java/com/Java/hotelmanagementsystem/email/service/EmailService.java
@@ -1,0 +1,13 @@
+package com.Java.hotelmanagementsystem.email.service;
+
+public interface EmailService {
+
+    /**
+     * Sends the password reset link to the dedicated email from the sender email.
+     *
+     * @param toEmail    The email to whom the password is to be sent.
+     * @param resetToken The token which is to be used to reset the token.
+     */
+    void sendResetPasswordEmail(String toEmail, String resetToken);
+
+}

--- a/src/main/java/com/Java/hotelmanagementsystem/email/service/EmailServiceImpl.java
+++ b/src/main/java/com/Java/hotelmanagementsystem/email/service/EmailServiceImpl.java
@@ -1,0 +1,46 @@
+package com.Java.hotelmanagementsystem.email.service;
+
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import static com.Java.hotelmanagementsystem.util.constants.EmailConstants.FAILED_TO_SEND_PASSWORD_RESET_EMAIL;
+import static com.Java.hotelmanagementsystem.util.constants.EmailConstants.RESET_LINK_MESSAGE;
+import static com.Java.hotelmanagementsystem.util.constants.EmailConstants.RESET_YOUR_PASSWORD_SUBJECT;
+
+@Service
+@Slf4j
+public class EmailServiceImpl implements EmailService {
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    @Value("${cors.originUrl}")
+    private String appUrl;
+
+    @Autowired
+    private JavaMailSender mailSender;
+
+    @Override
+    public void sendResetPasswordEmail(String toEmail, String resetToken) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true);
+
+            helper.setFrom(fromEmail);
+            helper.setTo(toEmail);
+            helper.setSubject(RESET_YOUR_PASSWORD_SUBJECT);
+            helper.setText(String.format(RESET_LINK_MESSAGE, appUrl, resetToken));
+
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            log.error(FAILED_TO_SEND_PASSWORD_RESET_EMAIL, e);
+            throw new RuntimeException(FAILED_TO_SEND_PASSWORD_RESET_EMAIL);
+        }
+    }
+}

--- a/src/main/java/com/Java/hotelmanagementsystem/email/service/PasswordResetService.java
+++ b/src/main/java/com/Java/hotelmanagementsystem/email/service/PasswordResetService.java
@@ -1,0 +1,24 @@
+package com.Java.hotelmanagementsystem.email.service;
+
+import com.Java.hotelmanagementsystem.email.dto.ForgotPasswordRequest;
+import com.Java.hotelmanagementsystem.email.dto.ResetPasswordRequest;
+import lombok.NonNull;
+
+public interface PasswordResetService {
+
+    /**
+     * Initializes the password reset process for the dedicated user.
+     *
+     * @param request The request containing the user email for whom the password reset link is to be generated.
+     * @return The confirmation on the password creation link.
+     */
+    String forgotPassword(@NonNull ForgotPasswordRequest request);
+
+    /**
+     * Resets the password with the provided token and the password
+     *
+     * @param resetPasswordRequest The request object with password and the token.
+     * @return The confirmation message for the reset password process.
+     */
+    String resetPassword(ResetPasswordRequest resetPasswordRequest);
+}

--- a/src/main/java/com/Java/hotelmanagementsystem/email/service/PasswordResetServiceImpl.java
+++ b/src/main/java/com/Java/hotelmanagementsystem/email/service/PasswordResetServiceImpl.java
@@ -1,0 +1,101 @@
+package com.Java.hotelmanagementsystem.email.service;
+import com.Java.hotelmanagementsystem.auth.helper.JwtService;
+import com.Java.hotelmanagementsystem.email.dto.ForgotPasswordRequest;
+import com.Java.hotelmanagementsystem.email.dto.ResetPasswordRequest;
+import com.Java.hotelmanagementsystem.email.model.PasswordResetToken;
+import com.Java.hotelmanagementsystem.email.repository.PasswordResetTokenRepository;
+import com.Java.hotelmanagementsystem.user.model.User;
+import com.Java.hotelmanagementsystem.user.service.UserService;
+import com.Java.hotelmanagementsystem.util.exception.GlobalExceptionWrapper;
+import io.micrometer.common.lang.NonNull;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import static com.Java.hotelmanagementsystem.util.constants.EmailConstants.*;
+import static com.Java.hotelmanagementsystem.util.constants.UserConstants.NOT_FOUND_MESSAGE;
+import static com.Java.hotelmanagementsystem.util.constants.UserConstants.USER;
+
+@Service
+@Slf4j
+public class PasswordResetServiceImpl implements PasswordResetService {
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private PasswordResetTokenRepository tokenRepository;
+
+    @Autowired
+    private EmailService emailService;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private PasswordEncoder encoder;
+
+    @Override
+    public String forgotPassword(@NonNull ForgotPasswordRequest request) {
+        User user = userService.findByEmail(request.getEmail()).orElseThrow(
+                () -> new GlobalExceptionWrapper.NotFoundException(String.format(NOT_FOUND_MESSAGE,
+                        USER.toLowerCase())));
+
+        createPasswordResetTokenForUser(user);
+        return SENT_RESET_PASSWORD_LINK;
+    }
+
+    /**
+     * Creates the password reset token and generates the reset link for the email provided.
+     *
+     * @param user The user for whom the password is to be reset.
+     */
+    @Transactional
+    private void createPasswordResetTokenForUser(User user) {
+        String token = jwtService.generateToken(user.getEmail());
+        PasswordResetToken myToken = new PasswordResetToken(user, token);
+        tokenRepository.deleteByUserId(user.getId());
+        tokenRepository.save(myToken);
+        emailService.sendResetPasswordEmail(user.getEmail(), token);
+    }
+
+    @Override
+    public String resetPassword(ResetPasswordRequest resetPasswordRequest) {
+        validatePasswordResetToken(resetPasswordRequest.getToken());
+
+        String email = jwtService.extractUsername(resetPasswordRequest.getToken());
+        User user = userService.findByEmail(email).orElseThrow(
+                () -> new GlobalExceptionWrapper.NotFoundException(String.format(NOT_FOUND_MESSAGE,
+                        USER.toLowerCase())));
+        changePassword(user, resetPasswordRequest.getPassword());
+
+        return PASSWORD_RESET_SUCCESSFUL;
+    }
+
+    /**
+     * Validates the token provided for the password reset process.
+     *
+     * @param token The jwt token used to validate the authenticity of the targeted user email.
+     */
+    private void validatePasswordResetToken(String token) {
+        PasswordResetToken passToken = tokenRepository.findByToken(token)
+                .orElseThrow(() -> new GlobalExceptionWrapper.NotFoundException(INVALID_TOKEN));
+
+        if (passToken.isExpired()) {
+            tokenRepository.delete(passToken);
+            throw new GlobalExceptionWrapper.BadRequestException(TOKEN_EXPIRED);
+        }
+    }
+
+    /**
+     * Changes the password for the given user and the password provided.
+     *
+     * @param user        The user entity of the user.
+     * @param newPassword The new password for the user.
+     */
+    private void changePassword(User user, String newPassword) {
+        user.setPassword(encoder.encode(newPassword));
+        userService.updateEntity(user);
+    }
+}

--- a/src/main/java/com/Java/hotelmanagementsystem/user/service/IUserService.java
+++ b/src/main/java/com/Java/hotelmanagementsystem/user/service/IUserService.java
@@ -10,5 +10,14 @@ public interface IUserService extends IGenericCrudService<User, UserDTO> {
      *
      * @return The instructor dto
      */
-    User fetchSelfInfo();
+    UserDTO fetchSelfInfo();
+
+
+    /**
+     * Updates the user entity.
+     *
+     * @param user The user entity to be updated.
+     * @return The confirmation message on whether the user is updated or not.
+     */
+    String updateEntity(User user);
 }

--- a/src/main/java/com/Java/hotelmanagementsystem/user/service/UserService.java
+++ b/src/main/java/com/Java/hotelmanagementsystem/user/service/UserService.java
@@ -100,7 +100,12 @@ public class UserService implements IUserService {
             authenticatedUser.setPhone(userDTO.getPhone());
         }
 
-        this.userRepository.save(UserMapper.toEntity(authenticatedUser));
+
+        return updateEntity(UserMapper.toEntity(authenticatedUser));
+    }
+    @Override
+    public String updateEntity(User user) {
+        this.userRepository.save(user);
         return String.format(UPDATED_SUCCESSFULLY_MESSAGE, USER);
     }
 

--- a/src/main/java/com/Java/hotelmanagementsystem/util/constants/EmailConstants.java
+++ b/src/main/java/com/Java/hotelmanagementsystem/util/constants/EmailConstants.java
@@ -1,0 +1,13 @@
+package com.Java.hotelmanagementsystem.util.constants;
+
+public class EmailConstants {
+
+    public static final String RESET_YOUR_PASSWORD_SUBJECT = "Reset Your Password";
+    public static final String RESET_LINK_MESSAGE = "Click the link to reset your password: %s/reset-password/%s";
+    public static final String FAILED_TO_SEND_PASSWORD_RESET_EMAIL = "Failed to send reset password email";
+    public static final String SENT_RESET_PASSWORD_LINK = "Reset password link sent to email";
+    public static final String PASSWORD_RESET_SUCCESSFUL = "Password reset successfully.";
+    public static final String INVALID_TOKEN = "Invalid token used.";
+    public static final String TOKEN_EXPIRED = "Token Expired.";
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=hotel-management-system
 spring.jpa.hibernate.ddl-auto=update
-spring.datasource.url=
+spring.datasource.url=jdbc:mysql://localhost:3306/hotel_management_system
 spring.datasource.username=root
 spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
@@ -12,10 +12,15 @@ logging.level.org.hibernate.\type.descriptor.sql.BasicBinder=TRACE
 
 # JWT SIGNING INFO
 jwt.secret=
-
 jwt.access-token-expiration=300000
 jwt.refresh-token-expiration=604800000
 # Cors Info
-
 cors.originUrl=
+# Email Setup
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=
+spring.mail.password=
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
 


### PR DESCRIPTION
## Description 

- Implemented Password mechanism for User/Admin incase of Forgotten.

## Changes Made

- Created  dto, model, service, repository and email constants.
- Renamed service for better naming convention.
- Added dependencies in gradle.build file.

## Testing Using Sample Data
**For Forgot Password**

- Endpoint: http://localhost:8081/api/v1/auth/forgot-password.
- Method: POST
- Payload: {"email: dawayoezer22@gmail.com"}
- Response
  {"status": true,"message":"Reset password link sent to email"}


## For Reset Password

- Endpoint: http://localhost:8081/api/v1/auth/reset-password.
- Method: POST
- Payload: {"email: dawayoezer22@gmail.com",password:"dawa12345678"}

- Response:
                {"status":true,"date":{"access Token":CiAgICAgICAgfQoKICAgICAgICB0aGlzLnVzZXJSZXBvc2l0b3J5LmRlbGV0ZUJ5SWQoYXV0aGVudGljYXRlZFVzZXIuZ2V0SWQoKSk7CiAgICAgICAgcmV0dXJuIFN0cmluZy5mb3JtYXQoREVMRVRFRF9TVUNDRVNTRlVMTFlfTUVTU0FHRSwgVVNFUik7CiAgICB9Cn0K"}}

## Screenshot

![Screenshot 2024-12-25 152915](https://github.com/user-attachments/assets/cc0e34b9-e00e-4b80-a076-ba6d63b9044d)


## CheckList

- [x] User should get an email after hitting the forgot password endpoint.
- [x] User should be able to login with the new password  after hitting the reset-password endpoint.


